### PR TITLE
Support the ability to dynamically reconfigure MMM-SimpleLogo

### DIFF
--- a/MMM-SimpleLogo.js
+++ b/MMM-SimpleLogo.js
@@ -31,7 +31,7 @@ Module.register("MMM-SimpleLogo", {
     },
 
     notificationReceived: function(notification, payload) {
-        if (notification == "MMM-SimpleLogo_CONFIG") {
+        if (notification == "SIMPLE_LOGO_UPDATE") {
             // stop auto-refresh (if any)
             if (this.config.refreshInterval > 0) {
                 clearInterval(this.interval);

--- a/MMM-SimpleLogo.js
+++ b/MMM-SimpleLogo.js
@@ -12,13 +12,13 @@ Module.register("MMM-SimpleLogo", {
         if (this.config.refreshInterval > 0) {
             var self = this;
             var imgsrc = self.config.fileUrl;
-            setInterval(function() {
+            this.interval = setInterval(function() {
                 img = document.querySelector(".simple-logo__container img[src*='" + imgsrc + "']");
                 imgsrc = self.config.fileUrl;
-		if(!imgsrc.includes("?"))
-			imgsrc += '?' + Date.now();
-		else
-			imgsrc += '&' + Date.now();
+                if(!imgsrc.includes("?"))
+                        imgsrc += '?' + Date.now();
+                else
+                        imgsrc += '&' + Date.now();
                 img.setAttribute('src', imgsrc);
             }, this.config.refreshInterval);
         }
@@ -28,6 +28,20 @@ Module.register("MMM-SimpleLogo", {
         return [
             this.file('css/mmm-simplelogo.css')
         ];
+    },
+
+    notificationReceived: function(notification, payload) {
+        if (notification == "MMM-SimpleLogo_CONFIG") {
+            // stop auto-refresh (if any)
+            if (this.config.refreshInterval > 0) {
+                clearInterval(this.interval);
+            }
+            // update with new parameters
+            for (var attr in payload) this.config[attr] = payload[attr];
+            // restart auto-refresh (if any)
+            this.start();
+            this.updateDom();
+        }
     },
 
     // Override dom generator.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The following properties can be configured:
 </table>
 
 ## Notification Events
-The MMM-SimpleLogo module supports the notification event `MMM-SimpleLogo_CONFIG` which allows the configuration to be dynamically modified.  As an example, the MMM-OnScreenMenu module might be used to dynamic adjust the `fileURL` parameter as follows:
+The MMM-SimpleLogo module supports the notification event `SIMPLE_LOGO_UPDATE` which allows the configuration to be dynamically modified.  As an example, the MMM-OnScreenMenu module might be used to dynamic adjust the `fileURL` parameter as follows:
 
     {
         module: "MMM-OnScreenMenu",
@@ -73,7 +73,7 @@ The MMM-SimpleLogo module supports the notification event `MMM-SimpleLogo_CONFIG
             menuItems: {
                 notify1: {
                     title: "Show Cat",
-                    notification: "MMM-SimpleLogo_CONFIG",
+                    notification: "SIMPLE_LOGO_UPDATE",
                     payload: {
                         fileUrl: "cat.jpg",
                         width: "750px"
@@ -81,7 +81,7 @@ The MMM-SimpleLogo module supports the notification event `MMM-SimpleLogo_CONFIG
                 },
                 notify2: {
                     title: "Show Dog",
-                    notification: "MMM-SimpleLogo_CONFIG",
+                    notification: "SIMPLE_LOGO_UPDATE",
                     payload: {
                         fileUrl: "dog.jpg",
                         width: "1050px"

--- a/README.md
+++ b/README.md
@@ -62,3 +62,32 @@ The following properties can be configured:
 		</tr>
 	</tbody>
 </table>
+
+## Notification Events
+The MMM-SimpleLogo module supports the notification event `MMM-SimpleLogo_CONFIG` which allows the configuration to be dynamically modified.  As an example, the MMM-OnScreenMenu module might be used to dynamic adjust the `fileURL` parameter as follows:
+
+    {
+        module: "MMM-OnScreenMenu",
+        position: "top_left",
+        config: {
+            menuItems: {
+                notify1: {
+                    title: "Show Cat",
+                    notification: "MMM-SimpleLogo_CONFIG",
+                    payload: {
+                        fileUrl: "cat.jpg",
+                        width: "750px"
+                    }
+                },
+                notify2: {
+                    title: "Show Dog",
+                    notification: "MMM-SimpleLogo_CONFIG",
+                    payload: {
+                        fileUrl: "dog.jpg",
+                        width: "1050px"
+                    }
+                }
+            }
+        }
+    }
+


### PR DESCRIPTION
This changeset adds support for a notification event (MMM-SimpleLogo_CONFIG) which allows the configuration of MMM-SimpleLogo to be dynamically updated at runtime